### PR TITLE
Add/fix dashdash support in optparse_long

### DIFF
--- a/optparse.c
+++ b/optparse.c
@@ -217,6 +217,9 @@ optparse_long(struct optparse *options,
     char *option = options->argv[options->optind];
     if (option == 0) {
         return -1;
+    } else if (is_dashdash(option)) {
+        options->optind++; /* consume "--" */
+        return -1;
     } else if (is_shortopt(option)) {
         return long_fallback(options, longopts, longindex);
     } else if (!is_longopt(option)) {


### PR DESCRIPTION
This changes the behaviour of optparse_long so that a '--' tags the end of options, just like optparse and getopt_long.
