### PR TITLE
README.md example code fixes to address compiler errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Here's the same thing translated to Optparse.
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#define OPTPARSE_IMPLEMENTATION
+#define OPTPARSE_API static
 #include "optparse.h"
 
 int main(int argc, char **argv)
@@ -138,10 +140,10 @@ int main(int argc, char **argv)
     bool brief = false;
     const char *color = "white";
     int delay = 0;
-
     struct optparse options;
-    optparse_init(&options, argv);
     int option;
+
+    optparse_init(&options, argv);
     while ((option = optparse(&options, "abc:d::")) != -1) {
         switch (option) {
         case 'a':
@@ -176,6 +178,8 @@ And here's a conversion to long options.
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#define OPTPARSE_IMPLEMENTATION
+#define OPTPARSE_API static
 #include "optparse.h"
 
 int main(int argc, char **argv)
@@ -184,9 +188,7 @@ int main(int argc, char **argv)
     bool brief = false;
     const char *color = "white";
     int delay = 0;
-
     struct optparse options;
-    optparse_init(&options, argv);
     struct optparse_long longopts[] = {
         {"amend", 'a', OPTPARSE_NONE},
         {"brief", 'b', OPTPARSE_NONE},
@@ -195,6 +197,8 @@ int main(int argc, char **argv)
         {0}
     };
     int option;
+
+    optparse_init(&options, argv);
     while ((option = optparse_long(&options, longopts, NULL)) != -1) {
         switch (option) {
         case 'a':
@@ -204,10 +208,10 @@ int main(int argc, char **argv)
             brief = true;
             break;
         case 'c':
-            color = optarg;
+            color = options.optarg;
             break;
         case 'd':
-            delay = optarg ? atoi(options.optarg) : 1;
+            delay = options.optarg ? atoi(options.optarg) : 1;
             break;
         case '?':
             fprintf(stderr, "%s: %s\n", argv[0], options.errmsg);
@@ -216,9 +220,12 @@ int main(int argc, char **argv)
     }
 
     /* Print remaining arguments. */
-    char *arg;
-    while ((arg = optparse_arg(&options)))
-        printf("%s\n", arg);
+    {
+        char *arg;
+        while ((arg = optparse_arg(&options)))
+            printf("%s\n", arg);
+    }
+
     return 0;
 }
 ~~~


### PR DESCRIPTION
There are still warnings, but the two optparse examples compile now.