### PR TITLE
Now accepts non-ambiguous partial long options,  a la GNU getopt_long…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 test
+examples/long
+examples/short
+examples/subcommands

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test : test.c optparse.h
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ test.c $(LDLIBS)
 
 run : test
-	./$< -abdfoo -c bar subcommand example.txt -a
+	./test -abdfoo -c bar subcommand example.txt -a
 
 clean :
 	rm -f test

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ and/or linkage (`static`, `__attribute__`, `__declspec`).
 
 ## Why not getopt()?
 
-The POSIX getopt option parser has three fatal flaws. These flaws are
+The POSIX getopt option parser has four fatal flaws. These flaws are
 solved by Optparse.
 
 1. The getopt parser state is stored entirely in global variables,
@@ -51,6 +51,10 @@ inaccessible. Optparse solves this by writing the error message to its
 errmsg field, which can be printed to anywhere. The downside to
 Optparse is that this error message will always be in English rather
 than the current locale.
+
+4. It's for POSIX.  If you want to port your code to a non-POSIX
+platform,  you may (or may not) find a POSIX-style getopt.  You will
+definitely find Optparse.
 
 ## Permutation
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Optparse
 
+(Note that this is a shameless copy of the [parent `skeeto/optparse`
+repo](https://www.github.com/skeeto/optparse),  except that `const` is
+used where reasonable;  non-ambiguous partial long options are handled,
+a la GNU getopt_long;  and I added text below mentioning that this
+extends `getopt` to non-POSIX systems,  which I consider to be a Big Deal.
+Other than that,  it's the same code.)
+
 Optparse is a public domain, portable, reentrant, embeddable, getopt-like
 option parser. As a single header file, it's trivially dropped into any
 project. It supports POSIX getopt option strings, GNU-style long options,

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Optparse
 
-Optparse is a public domain, portable, reentrant, embeddable,
-getopt-like option parser. It's a single header file and can be
-trivially dropped into any project. It supports POSIX getopt option
-strings, GNU-style long options, argument permutation, and subcommand
-processing.
+Optparse is a public domain, portable, reentrant, embeddable, getopt-like
+option parser. As a single header file, it's trivially dropped into any
+project. It supports POSIX getopt option strings, GNU-style long options,
+argument permutation, and subcommand processing.
 
 To get the implementation, define `OPTPARSE_IMPLEMENTATION` before
 including `optparse.h`.
@@ -134,6 +133,7 @@ Here's the same thing translated to Optparse.
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
+
 #define OPTPARSE_IMPLEMENTATION
 #define OPTPARSE_API static
 #include "optparse.h"
@@ -183,6 +183,7 @@ And here's a conversion to long options.
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
+
 #define OPTPARSE_IMPLEMENTATION
 #define OPTPARSE_API static
 #include "optparse.h"
@@ -234,3 +235,11 @@ int main(int argc, char **argv)
     return 0;
 }
 ~~~
+
+## Subcommand Parsing
+
+To parse subcommands, first parse options with permutation disabled. These
+are the "global" options that come before the subcommand. Then parse the
+remainder, optionally permuting, as a new option array.
+
+See `examples/subcommands.c` for a complete, working example.

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,18 @@
+CC      = cc
+CFLAGS  = -ansi -pedantic -Wall -Wextra -Wno-unused-function -Wno-unused-but-set-variable -g3
+LDFLAGS =
+LDLIBS  =
+
+all: short$(EXE) long$(EXE) subcommands$(EXE)
+
+short$(EXE): short.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ short.c ../optparse.h $(LDLIBS)
+
+long$(EXE): long.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ long.c ../optparse.h $(LDLIBS)
+
+subcommands$(EXE): subcommands.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ subcommands.c ../optparse.h $(LDLIBS)
+
+clean:
+	rm -f short$(EXE) long$(EXE) subcommands$(EXE)

--- a/examples/long.c
+++ b/examples/long.c
@@ -1,0 +1,56 @@
+/* This is free and unencumbered software released into the public domain. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define OPTPARSE_IMPLEMENTATION
+#define OPTPARSE_API static
+#include "../optparse.h"
+
+int main(int argc, char **argv)
+{
+    struct optparse_long longopts[] = {
+        {"amend", 'a', OPTPARSE_NONE},
+        {"brief", 'b', OPTPARSE_NONE},
+        {"color", 'c', OPTPARSE_REQUIRED},
+        {"delay", 'd', OPTPARSE_OPTIONAL},
+        {0}
+    };
+
+    bool amend = false;
+    bool brief = false;
+    const char *color = "white";
+    int delay = 0;
+
+    char *arg;
+    int option;
+    struct optparse options;
+
+    (void)argc;
+    optparse_init(&options, argv);
+    while ((option = optparse_long(&options, longopts, NULL)) != -1) {
+        switch (option) {
+        case 'a':
+            amend = true;
+            break;
+        case 'b':
+            brief = true;
+            break;
+        case 'c':
+            color = options.optarg;
+            break;
+        case 'd':
+            delay = options.optarg ? atoi(options.optarg) : 1;
+            break;
+        case '?':
+            fprintf(stderr, "%s: %s\n", argv[0], options.errmsg);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    /* Print remaining arguments. */
+    while ((arg = optparse_arg(&options)))
+        printf("%s\n", arg);
+
+    return 0;
+}

--- a/examples/long.c
+++ b/examples/long.c
@@ -7,9 +7,9 @@
 #define OPTPARSE_API static
 #include "../optparse.h"
 
-int main(int argc, char **argv)
+int main(int argc, const char **argv)
 {
-    struct optparse_long longopts[] = {
+    const struct optparse_long longopts[] = {
         {"amend", 'a', OPTPARSE_NONE},
         {"brief", 'b', OPTPARSE_NONE},
         {"color", 'c', OPTPARSE_REQUIRED},
@@ -22,7 +22,7 @@ int main(int argc, char **argv)
     const char *color = "white";
     int delay = 0;
 
-    char *arg;
+    const char *arg;
     int option;
     struct optparse options;
 

--- a/examples/short.c
+++ b/examples/short.c
@@ -1,0 +1,47 @@
+/* This is free and unencumbered software released into the public domain. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define OPTPARSE_IMPLEMENTATION
+#define OPTPARSE_API static
+#include "../optparse.h"
+
+int main(int argc, char **argv)
+{
+    bool amend = false;
+    bool brief = false;
+    const char *color = "white";
+    int delay = 0;
+
+    char *arg;
+    int option;
+    struct optparse options;
+
+    (void)argc;
+    optparse_init(&options, argv);
+    while ((option = optparse(&options, "abc:d::")) != -1) {
+        switch (option) {
+        case 'a':
+            amend = true;
+            break;
+        case 'b':
+            brief = true;
+            break;
+        case 'c':
+            color = options.optarg;
+            break;
+        case 'd':
+            delay = options.optarg ? atoi(options.optarg) : 1;
+            break;
+        case '?':
+            fprintf(stderr, "%s: %s\n", argv[0], options.errmsg);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    /* Print remaining arguments. */
+    while ((arg = optparse_arg(&options)))
+        printf("%s\n", arg);
+    return 0;
+}

--- a/examples/short.c
+++ b/examples/short.c
@@ -7,14 +7,14 @@
 #define OPTPARSE_API static
 #include "../optparse.h"
 
-int main(int argc, char **argv)
+int main(int argc, const char **argv)
 {
     bool amend = false;
     bool brief = false;
     const char *color = "white";
     int delay = 0;
 
-    char *arg;
+    const char *arg;
     int option;
     struct optparse options;
 

--- a/examples/subcommands.c
+++ b/examples/subcommands.c
@@ -1,0 +1,120 @@
+/* This is free and unencumbered software released into the public domain. */
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define OPTPARSE_IMPLEMENTATION
+#include "../optparse.h"
+
+static int cmd_echo(char **argv)
+{
+    int i, option;
+    bool newline = true;
+    struct optparse options;
+
+    optparse_init(&options, argv);
+    options.permute = 0;
+    while ((option = optparse(&options, "hn")) != -1) {
+        switch (option) {
+        case 'h':
+            puts("usage: echo [-hn] [ARG]...");
+            return 0;
+        case 'n':
+            newline = false;
+            break;
+        case '?':
+            fprintf(stderr, "%s: %s\n", argv[0], options.errmsg);
+            return 1;
+        }
+    }
+    argv += options.optind;
+
+    for (i = 0; argv[i]; i++) {
+        printf("%s%s", i  ? " " : "", argv[i]);
+    }
+    if (newline) {
+        putchar('\n');
+    }
+
+    fflush(stdout);
+    return !!ferror(stdout);
+}
+
+static int cmd_sleep(char **argv)
+{
+    int i, option;
+    struct optparse options;
+
+    optparse_init(&options, argv);
+    while ((option = optparse(&options, "h")) != -1) {
+        switch (option) {
+        case 'h':
+            puts("usage: sleep [-h] [NUMBER]...");
+            return 0;
+        case '?':
+            fprintf(stderr, "%s: %s\n", argv[0], options.errmsg);
+            return 1;
+        }
+    }
+
+    for (i = 0; argv[i]; i++) {
+        if (sleep(atoi(argv[i]))) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static void
+usage(FILE *f)
+{
+    fprintf(f, "usage: example [-h] <echo|sleep> [OPTION]...\n");
+}
+
+int main(int argc, char **argv)
+{
+    int i, option;
+    char **subargv;
+    struct optparse options;
+
+    static const struct {
+        char name[8];
+        int (*cmd)(char **);
+    } cmds[] = {
+        {"echo",  cmd_echo },
+        {"sleep", cmd_sleep},
+    };
+    int ncmds = sizeof(cmds) / sizeof(*cmds);
+
+    (void)argc;
+    optparse_init(&options, argv);
+    options.permute = 0;
+    while ((option = optparse(&options, "hp")) != -1) {
+        switch (option) {
+        case 'h':
+            usage(stdout);
+            return 0;
+        case '?':
+            usage(stderr);
+            fprintf(stderr, "%s: %s\n", argv[0], options.errmsg);
+            return 1;
+        }
+    }
+
+    subargv = argv + options.optind;
+    if (!subargv[0]) {
+        fprintf(stderr, "%s: missing subcommand\n", argv[0]);
+        usage(stderr);
+        return 1;
+    }
+
+    for (i = 0; i < ncmds; i++) {
+        if (!strcmp(cmds[i].name, subargv[0])) {
+            return cmds[i].cmd(subargv);
+        }
+    }
+    fprintf(stderr, "%s: invalid subcommand: %s\n", argv[0], subargv[0]);
+    return 1;
+}

--- a/examples/subcommands.c
+++ b/examples/subcommands.c
@@ -91,7 +91,7 @@ int main(int argc, const char **argv)
     (void)argc;
     optparse_init(&options, argv);
     options.permute = 0;
-    while ((option = optparse(&options, "hp")) != -1) {
+    while ((option = optparse(&options, "h")) != -1) {
         switch (option) {
         case 'h':
             usage(stdout);

--- a/examples/subcommands.c
+++ b/examples/subcommands.c
@@ -8,7 +8,7 @@
 #define OPTPARSE_IMPLEMENTATION
 #include "../optparse.h"
 
-static int cmd_echo(char **argv)
+static int cmd_echo(const char **argv)
 {
     int i, option;
     bool newline = true;
@@ -42,7 +42,7 @@ static int cmd_echo(char **argv)
     return !!ferror(stdout);
 }
 
-static int cmd_sleep(char **argv)
+static int cmd_sleep(const char **argv)
 {
     int i, option;
     struct optparse options;
@@ -73,20 +73,20 @@ usage(FILE *f)
     fprintf(f, "usage: example [-h] <echo|sleep> [OPTION]...\n");
 }
 
-int main(int argc, char **argv)
+int main(int argc, const char **argv)
 {
     int i, option;
-    char **subargv;
+    const char **subargv;
     struct optparse options;
 
     static const struct {
         char name[8];
-        int (*cmd)(char **);
+        int (*cmd)(const char **);
     } cmds[] = {
         {"echo",  cmd_echo },
         {"sleep", cmd_sleep},
     };
-    int ncmds = sizeof(cmds) / sizeof(*cmds);
+    const int ncmds = sizeof(cmds) / sizeof(*cmds);
 
     (void)argc;
     optparse_init(&options, argv);

--- a/optparse.h
+++ b/optparse.h
@@ -54,11 +54,11 @@
 #endif
 
 struct optparse {
-    char **argv;
+    const char **argv;
     int permute;
     int optind;
     int optopt;
-    char *optarg;
+    const char *optarg;
     char errmsg[64];
     int subopt;
 };
@@ -79,7 +79,7 @@ struct optparse_long {
  * Initializes the parser state.
  */
 OPTPARSE_API
-void optparse_init(struct optparse *options, char **argv);
+void optparse_init(struct optparse *options, const char **argv);
 
 /**
  * Read the next option in the argv array.
@@ -114,7 +114,7 @@ int optparse_long(struct optparse *options,
  * ignore the value of optind.
  */
 OPTPARSE_API
-char *optparse_arg(struct optparse *options);
+const char *optparse_arg(struct optparse *options);
 
 /* Implementation */
 #ifdef OPTPARSE_IMPLEMENTATION
@@ -142,7 +142,7 @@ optparse_error(struct optparse *options, const char *msg, const char *data)
 
 OPTPARSE_API
 void
-optparse_init(struct optparse *options, char **argv)
+optparse_init(struct optparse *options, const char **argv)
 {
     options->argv = argv;
     options->permute = 1;
@@ -171,9 +171,9 @@ optparse_is_longopt(const char *arg)
 }
 
 static void
-optparse_permute(struct optparse *options, int index)
+optparse_permute(struct optparse *options, const int index)
 {
-    char *nonoption = options->argv[index];
+    const char *nonoption = options->argv[index];
     int i;
     for (i = index; i < options->optind - 1; i++)
         options->argv[i] = options->argv[i + 1];
@@ -181,7 +181,7 @@ optparse_permute(struct optparse *options, int index)
 }
 
 static int
-optparse_argtype(const char *optstring, char c)
+optparse_argtype(const char *optstring, const char c)
 {
     int count = OPTPARSE_NONE;
     if (c == ':')
@@ -199,8 +199,8 @@ int
 optparse(struct optparse *options, const char *optstring)
 {
     int type;
-    char *next;
-    char *option = options->argv[options->optind];
+    const char *next;
+    const char *option = options->argv[options->optind];
     options->errmsg[0] = '\0';
     options->optopt = 0;
     options->optarg = 0;
@@ -267,10 +267,10 @@ optparse(struct optparse *options, const char *optstring)
 }
 
 OPTPARSE_API
-char *
+const char *
 optparse_arg(struct optparse *options)
 {
-    char *option = options->argv[options->optind];
+    const char *option = options->argv[options->optind];
     options->subopt = 0;
     if (option != 0)
         options->optind++;
@@ -278,7 +278,7 @@ optparse_arg(struct optparse *options)
 }
 
 static int
-optparse_longopts_end(const struct optparse_long *longopts, int i)
+optparse_longopts_end(const struct optparse_long *longopts, const int i)
 {
     return !longopts[i].longname && !longopts[i].shortname;
 }
@@ -313,8 +313,8 @@ optparse_longopts_match(const char *longname, const char *option)
 }
 
 /* Return the part after "=", or NULL. */
-static char *
-optparse_longopts_arg(char *option)
+static const char *
+optparse_longopts_arg(const char *option)
 {
     for (; *option && *option != '='; option++);
     if (*option == '=')
@@ -351,7 +351,7 @@ optparse_long(struct optparse *options,
               int *longindex)
 {
     int i, matched_idx;
-    char *option = options->argv[options->optind];
+    const char *option = options->argv[options->optind];
     if (option == 0) {
         return -1;
     } else if (optparse_is_dashdash(option)) {
@@ -387,7 +387,7 @@ optparse_long(struct optparse *options,
         }
 
     if( matched_idx >= 0) {
-        char *arg;
+        const char *arg;
         const char *name = longopts[matched_idx].longname;
 
         i = matched_idx;

--- a/optparse.h
+++ b/optparse.h
@@ -113,6 +113,7 @@ int optparse_long(struct optparse *options,
  * subcommand returned by optparse_arg(). This function allows you to
  * ignore the value of optind.
  */
+
 OPTPARSE_API
 const char *optparse_arg(struct optparse *options);
 
@@ -400,9 +401,11 @@ optparse_long(struct optparse *options,
         } if (arg != 0) {
             options->optarg = arg;
         } else if (longopts[i].argtype == OPTPARSE_REQUIRED) {
-            options->optarg = options->argv[options->optind++];
+            options->optarg = options->argv[options->optind];
             if (options->optarg == 0)
                 return optparse_error(options, OPTPARSE_MSG_MISSING, name);
+            else
+                options->optind++;
         }
         return options->optopt;
     }

--- a/optparse.h
+++ b/optparse.h
@@ -54,12 +54,12 @@
 #endif
 
 struct optparse {
+    char errmsg[64];
     const char **argv;
+    const char *optarg;
     int permute;
     int optind;
     int optopt;
-    const char *optarg;
-    char errmsg[64];
     int subopt;
 };
 

--- a/optparse.h
+++ b/optparse.h
@@ -290,7 +290,7 @@ optparse_from_long(const struct optparse_long *longopts, char *optstring)
     char *p = optstring;
     int i;
     for (i = 0; !optparse_longopts_end(longopts, i); i++) {
-        if (longopts[i].shortname) {
+        if (longopts[i].shortname && longopts[i].shortname < 127) {
             int a;
             *p++ = longopts[i].shortname;
             for (a = 0; a < (int)longopts[i].argtype; a++)

--- a/optparse.h
+++ b/optparse.h
@@ -147,7 +147,7 @@ optparse_init(struct optparse *options, const char **argv)
 {
     options->argv = argv;
     options->permute = 1;
-    options->optind = 1;
+    options->optind = argv[0] != 0;
     options->subopt = 0;
     options->optarg = 0;
     options->errmsg[0] = '\0';

--- a/test.c
+++ b/test.c
@@ -55,16 +55,20 @@ void try_optparse_long( const char **argv)
         {"brief", 'b', OPTPARSE_NONE},
         {"color", 'c', OPTPARSE_REQUIRED},
         {"delay", 'd', OPTPARSE_OPTIONAL},
+        {"erase", 256, OPTPARSE_REQUIRED},
         {0, 0, 0}
     };
 
     print_argv(argv);
     optparse_init(&options, argv);
     while ((opt = optparse_long(&options, longopts, &longindex)) != -1) {
+        char buf[2] = {0, 0};
         if (opt == '?')
             printf("%s: %s\n", argv[0], options.errmsg);
-        printf("%c (%d, %d) = '%s'\n",
-               opt, options.optind, longindex, options.optarg);
+        buf[0] = opt;
+        printf("%-6s(%d, %d) = '%s'\n",
+               opt < 127 ? buf : longopts[longindex].longname,
+               options.optind, longindex, options.optarg);
     }
     printf("optind = %d\n", options.optind);
     while ((arg = optparse_arg(&options)))
@@ -76,7 +80,7 @@ int main(int argc, char **argv)
 #ifdef EXAMPLE
     const char *long_argv[] = {
         "./main", "--amend", "-b", "--color", "red", "--delay=22",
-        "subcommand", "example.txt", "--amend", NULL
+        "subcommand", "example.txt", "--amend", "--erase", "all", NULL
     };
 #endif
     size_t size = (argc + 1) * sizeof(*argv);

--- a/test.c
+++ b/test.c
@@ -7,7 +7,7 @@
 #include <string.h>
 #include <getopt.h>
 
-void print_argv(char **argv)
+void print_argv(const char **argv)
 {
     while (*argv)
         printf("%s ", *argv++);
@@ -18,7 +18,7 @@ void try_getopt(int argc, char **argv)
 {
     int opt;
 
-    print_argv(argv);
+    print_argv((const char **)argv);
     while ((opt = getopt(argc, argv, "abc:d::")) != -1) {
         printf("%c (%d) = '%s'\n", opt, optind, optarg);
     }
@@ -27,10 +27,10 @@ void try_getopt(int argc, char **argv)
         printf("argument: %s\n", argv[optind]);
 }
 
-void try_optparse(char **argv)
+void try_optparse( const char **argv)
 {
     int opt;
-    char *arg;
+    const char *arg;
     struct optparse options;
 
     print_argv(argv);
@@ -45,12 +45,12 @@ void try_optparse(char **argv)
         printf("argument: %s\n", arg);
 }
 
-void try_optparse_long(char **argv)
+void try_optparse_long( const char **argv)
 {
-    char *arg;
+    const char *arg;
     int opt, longindex;
     struct optparse options;
-    struct optparse_long longopts[] = {
+    const struct optparse_long longopts[] = {
         {"amend", 'a', OPTPARSE_NONE},
         {"brief", 'b', OPTPARSE_NONE},
         {"color", 'c', OPTPARSE_REQUIRED},
@@ -73,10 +73,12 @@ void try_optparse_long(char **argv)
 
 int main(int argc, char **argv)
 {
-    char *long_argv[] = {
+#ifdef EXAMPLE
+    const char *long_argv[] = {
         "./main", "--amend", "-b", "--color", "red", "--delay=22",
         "subcommand", "example.txt", "--amend", NULL
     };
+#endif
     size_t size = (argc + 1) * sizeof(*argv);
     char **argv_copy = malloc(size);
 
@@ -86,9 +88,10 @@ int main(int argc, char **argv)
 
     memcpy(argv_copy, argv, size);
     printf("\nOPTPARSE\n");
-    try_optparse(argv_copy);
+    try_optparse( (const char **)argv_copy);
 
+    memcpy(argv_copy, argv, size);
     printf("\nOPTPARSE LONG\n");
-    try_optparse_long(long_argv);
+    try_optparse_long( (const char **)argv_copy);
     return 0;
 }

--- a/test.c
+++ b/test.c
@@ -5,29 +5,18 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <getopt.h>
 
-void print_argv(const char **argv)
+static void
+print_argv(const char **argv)
 {
-    while (*argv)
+    while (*argv) {
         printf("%s ", *argv++);
+    }
     printf("\n");
 }
 
-void try_getopt(int argc, char **argv)
-{
-    int opt;
-
-    print_argv((const char **)argv);
-    while ((opt = getopt(argc, argv, "abc:d::")) != -1) {
-        printf("%c (%d) = '%s'\n", opt, optind, optarg);
-    }
-    printf("optind = %d\n", optind);
-    for (; optind < argc; optind++)
-        printf("argument: %s\n", argv[optind]);
-}
-
-void try_optparse( const char **argv)
+static void
+try_optparse( const char **argv)
 {
     int opt;
     const char *arg;
@@ -36,21 +25,24 @@ void try_optparse( const char **argv)
     print_argv(argv);
     optparse_init(&options, argv);
     while ((opt = optparse(&options, "abc:d::")) != -1) {
-        if (opt == '?')
+        if (opt == '?') {
             printf("%s: %s\n", argv[0], options.errmsg);
+        }
         printf("%c (%d) = '%s'\n", opt, options.optind, options.optarg);
     }
     printf("optind = %d\n", options.optind);
-    while ((arg = optparse_arg(&options)))
+    while ((arg = optparse_arg(&options))) {
         printf("argument: %s\n", arg);
+    }
 }
 
-void try_optparse_long( const char **argv)
+static void
+try_optparse_long( const char **argv)
 {
     const char *arg;
     int opt, longindex;
     struct optparse options;
-    const struct optparse_long longopts[] = {
+    struct optparse_long longopts[] = {
         {"amend", 'a', OPTPARSE_NONE},
         {"brief", 'b', OPTPARSE_NONE},
         {"color", 'c', OPTPARSE_REQUIRED},
@@ -63,39 +55,248 @@ void try_optparse_long( const char **argv)
     optparse_init(&options, argv);
     while ((opt = optparse_long(&options, longopts, &longindex)) != -1) {
         char buf[2] = {0, 0};
-        if (opt == '?')
+        if (opt == '?') {
             printf("%s: %s\n", argv[0], options.errmsg);
+        }
         buf[0] = opt;
         printf("%-6s(%d, %d) = '%s'\n",
                opt < 127 ? buf : longopts[longindex].longname,
                options.optind, longindex, options.optarg);
     }
     printf("optind = %d\n", options.optind);
-    while ((arg = optparse_arg(&options)))
+    while ((arg = optparse_arg(&options))) {
         printf("argument: %s\n", arg);
+    }
 }
 
-int main(int argc, char **argv)
+static int
+manual_test(int argc, char **argv)
 {
-#ifdef EXAMPLE
-    const char *long_argv[] = {
-        "./main", "--amend", "-b", "--color", "red", "--delay=22",
-        "subcommand", "example.txt", "--amend", "--erase", "all", NULL
-    };
-#endif
     size_t size = (argc + 1) * sizeof(*argv);
     char **argv_copy = malloc(size);
-
-    memcpy(argv_copy, argv, size);
-    printf("GETOPT\n");
-    try_getopt(argc, argv_copy);
 
     memcpy(argv_copy, argv, size);
     printf("\nOPTPARSE\n");
     try_optparse( (const char **)argv_copy);
 
-    memcpy(argv_copy, argv, size);
     printf("\nOPTPARSE LONG\n");
-    try_optparse_long( (const char **)argv_copy);
+    try_optparse_long( (const char **)argv);
     return 0;
+}
+
+static int
+testsuite(void)
+{
+    struct config {
+        char amend;
+        char brief;
+        const char *color;
+        int delay;
+        int erase;
+    };
+    struct {
+        const char *argv[8];
+        struct config conf;
+        char *args[8];
+        char *err;
+    } t[] = {
+        {
+            {"", "--", "foobar", 0},
+            {0, 0, 0, 0, 0},
+            {"foobar", 0},
+            0
+        },
+        {
+            {"", "-a", "-b", "-c", "-d", "10", "-e", 0},
+            {1, 1, "", 10, 1},
+            {0},
+            0
+        },
+        {
+            {
+                "",
+                "--amend",
+                "--brief",
+                "--color",
+                "--delay",
+                "10",
+                "--erase",
+                0
+            },
+            {1, 1, "", 10, 1},
+            {0},
+            0
+        },
+        {
+            {"", "-a", "-b", "-cred", "-d", "10", "-e", 0},
+            {1, 1, "red", 10, 1},
+            {0},
+            0
+        },
+        {
+            {"", "-abcblue", "-d10", "foobar", 0},
+            {1, 1, "blue", 10, 0},
+            {"foobar", 0},
+            0
+        },
+        {
+            {"", "--color=red", "-d", "10", "--", "foobar", 0},
+            {0, 0, "red", 10, 0},
+            {"foobar", 0},
+            0
+        },
+        {
+            {"", "-eeeeee", 0},
+            {0, 0, 0, 0, 6},
+            {0},
+            0
+        },
+        {
+            {"", "--delay", 0},
+            {0, 0, 0, 0, 0},
+            {0},
+            OPTPARSE_MSG_MISSING
+        },
+        {
+            {"", "--foo", "bar", 0},
+            {0, 0, 0, 0, 0},
+            {"--foo", "bar", 0},
+            OPTPARSE_MSG_INVALID
+        },
+        {
+            {"", "-x", 0},
+            {0, 0, 0, 0, 0},
+            {"-x", 0},
+            OPTPARSE_MSG_INVALID
+        },
+        {
+            {"", "-", 0},
+            {0, 0, 0, 0, 0},
+            {"-", 0},
+            0
+        },
+        {
+            {"", "-e", "foo", "bar", "baz", "-a", "quux", 0},
+            {1, 0, 0, 0, 1},
+            {"foo", "bar", "baz", "quux", 0},
+            0
+        },
+        {
+            {"", "foo", "--delay", "1234", "bar", "-cred", 0},
+            {0, 0, "red", 1234, 0},
+            {"foo", "bar", 0},
+            0
+        },
+    };
+    int ntests = sizeof(t) / sizeof(*t);
+    int i, nfails = 0;
+    struct optparse_long longopts[] = {
+        {"amend", 'a', OPTPARSE_NONE},
+        {"brief", 'b', OPTPARSE_NONE},
+        {"color", 'c', OPTPARSE_OPTIONAL},
+        {"delay", 'd', OPTPARSE_REQUIRED},
+        {"erase", 'e', OPTPARSE_NONE},
+        {0, 0, 0}
+    };
+
+    for (i = 0; i < ntests; i++) {
+        int j, opt, longindex;
+        const char *arg, *err = NULL;
+        struct optparse options;
+        struct config conf = {0, 0, 0, 0, 0};
+
+        optparse_init(&options, t[i].argv);
+        while ((opt = optparse_long(&options, longopts, &longindex)) != -1) {
+            switch (opt) {
+            case 'a': conf.amend = 1; break;
+            case 'b': conf.brief = 1; break;
+            case 'c': conf.color = options.optarg ? options.optarg : ""; break;
+            case 'd': conf.delay = atoi(options.optarg); break;
+            case 'e': conf.erase++; break;
+            default: err = options.errmsg;
+            }
+        }
+
+        if (conf.amend != t[i].conf.amend) {
+            nfails++;
+            printf("FAIL (%2d): expected amend %d, got %d\n",
+                   i, t[i].conf.amend, conf.amend);
+        }
+
+        if (conf.brief != t[i].conf.brief) {
+            nfails++;
+            printf("FAIL (%2d): expected brief %d, got %d\n",
+                   i, t[i].conf.brief, conf.brief);
+        }
+
+        if (t[i].conf.color) {
+            if (!conf.color || strcmp(conf.color, t[i].conf.color)) {
+                nfails++;
+                printf("FAIL (%2d): expected color %s, got %s\n",
+                       i, t[i].conf.color, conf.color ? conf.color : "(nil)");
+            }
+        } else {
+            if (conf.color) {
+                nfails++;
+                printf("FAIL (%2d): expected no color, got %s\n",
+                       i, conf.color);
+            }
+        }
+
+        if (conf.delay != t[i].conf.delay) {
+            nfails++;
+            printf("FAIL (%2d): expected delay %d, got %d\n",
+                   i, t[i].conf.delay, conf.delay);
+        }
+
+        if (conf.erase != t[i].conf.erase) {
+            nfails++;
+            printf("FAIL (%2d): expected erase %d, got %d\n",
+                   i, t[i].conf.erase, conf.erase);
+        }
+
+        if (t[i].err) {
+            if (!err || strncmp(err, t[i].err, strlen(t[i].err))) {
+                nfails++;
+                printf("FAIL (%2d): expected error '%s', got %s\n",
+                       i, t[i].err, err && err[0] ? err : "(nil)");
+            }
+
+        } else {
+            if (err) {
+                nfails++;
+                printf("FAIL (%2d): expected no error, got %s\n",
+                       i, err);
+            }
+
+            for (j = 0; t[i].args[j]; j++) {
+                arg = optparse_arg(&options);
+                if (!arg || strcmp(arg, t[i].args[j])) {
+                    nfails++;
+                    printf("FAIL (%2d): expected arg %s, got %s\n",
+                           i, t[i].args[j], arg ? arg : "(nil)");
+                }
+            }
+            if ((arg = optparse_arg(&options))) {
+                nfails++;
+                printf("FAIL (%2d): expected no more args, got %s\n",
+                       i, arg);
+            }
+        }
+    }
+
+    if (nfails == 0) {
+        puts("All tests pass.");
+    }
+    return nfails != 0;
+}
+
+int
+main(int argc, char **argv)
+{
+    if (argc > 1) {
+        return manual_test(argc, argv);
+    } else {
+        return testsuite();
+    }
 }


### PR DESCRIPTION
First: I added the Github URL for your project to the header so I'll know whence the code came and where to look for updates.

Second:  GNU getopts_long() allows truncating long options as long as the result isn't ambiguous.  If you have options --color and --collapse,  for example,  --colo or --colla or --coll will be accepted.  --co or --col won't be.  I've revised `optparse` to behave similarly.

The GNU version does give a better error message;  for example, --co would get you

`./getopt: option '--co' is ambiguous; possibilities: '--color' '--collapse'`

I haven't gotten quite that fancy.  (If I did,  `msgbuf[64]` would probably need enlarging.)

Third and not least... thank you very much!  I have code that has to work on Linux,  *BSD,  and Windows; other getopts wouldn't have worked for me.