### PR TITLE
Make makefile POSIX compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test : test.c optparse.h
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ test.c $(LDLIBS)
 
 run : test
-	./$< -abdfoo -c bar subcommand example.txt -a
+	./test -abdfoo -c bar subcommand example.txt -a
 
 clean :
 	rm -f test


### PR DESCRIPTION
For POSIX make, the `$<` macro is only defined for inference rules and
the `.DEFAULT` rule. It is unspecified in target rules, e.g. for BSD
make it is left empty, so `make run` will fail under BSDs.

The new makefile not strictly POSIX since it doesn't have the `.POSIX` rule , but it should fix the issue under BSDs.