### PR TITLE
Allow '?' to be returned as a parsed option only

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
         case 'd':
             delay = optarg ? atoi(optarg) : 1;
             break;
-        case '?':
+        default:
             exit(EXIT_FAILURE);
         }
     }
@@ -119,7 +119,7 @@ int main(int argc, char **argv)
     /* Print remaining arguments. */
     for (; optind < argc; optind++)
         printf("%s\n", argv[optind]);
-    return 0;
+    return EXIT_SUCCESS;
 }
 ~~~
 
@@ -160,7 +160,7 @@ int main(int argc, char **argv)
         case 'd':
             delay = options.optarg ? atoi(options.optarg) : 1;
             break;
-        case '?':
+        default:
             fprintf(stderr, "%s: %s\n", argv[0], options.errmsg);
             exit(EXIT_FAILURE);
         }
@@ -169,7 +169,7 @@ int main(int argc, char **argv)
     /* Print remaining arguments. */
     while ((arg = optparse_arg(&options)))
         printf("%s\n", arg);
-    return 0;
+    return EXIT_SUCCESS;
 }
 ~~~
 
@@ -218,7 +218,7 @@ int main(int argc, char **argv)
         case 'd':
             delay = options.optarg ? atoi(options.optarg) : 1;
             break;
-        case '?':
+        default:
             fprintf(stderr, "%s: %s\n", argv[0], options.errmsg);
             exit(EXIT_FAILURE);
         }
@@ -228,7 +228,7 @@ int main(int argc, char **argv)
     while ((arg = optparse_arg(&options)))
         printf("%s\n", arg);
 
-    return 0;
+    return EXIT_SUCCESS;
 }
 ~~~
 

--- a/examples/long.c
+++ b/examples/long.c
@@ -42,7 +42,7 @@ int main(int argc, char **argv)
         case 'd':
             delay = options.optarg ? atoi(options.optarg) : 1;
             break;
-        case '?':
+        default:
             fprintf(stderr, "%s: %s\n", argv[0], options.errmsg);
             exit(EXIT_FAILURE);
         }
@@ -52,5 +52,5 @@ int main(int argc, char **argv)
     while ((arg = optparse_arg(&options)))
         printf("%s\n", arg);
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/examples/short.c
+++ b/examples/short.c
@@ -34,7 +34,7 @@ int main(int argc, char **argv)
         case 'd':
             delay = options.optarg ? atoi(options.optarg) : 1;
             break;
-        case '?':
+        default:
             fprintf(stderr, "%s: %s\n", argv[0], options.errmsg);
             exit(EXIT_FAILURE);
         }
@@ -43,5 +43,6 @@ int main(int argc, char **argv)
     /* Print remaining arguments. */
     while ((arg = optparse_arg(&options)))
         printf("%s\n", arg);
-    return 0;
+
+    return EXIT_SUCCESS;
 }

--- a/examples/subcommands.c
+++ b/examples/subcommands.c
@@ -16,17 +16,18 @@ static int cmd_echo(char **argv)
 
     optparse_init(&options, argv);
     options.permute = 0;
-    while ((option = optparse(&options, "hn")) != -1) {
+    while ((option = optparse(&options, "?hn")) != -1) {
         switch (option) {
+        case '?':
         case 'h':
-            puts("usage: echo [-hn] [ARG]...");
-            return 0;
+            puts("usage: echo [-?hn] [ARG]...");
+            return EXIT_SUCCESS;
         case 'n':
             newline = false;
             break;
-        case '?':
+        default:
             fprintf(stderr, "%s: %s\n", argv[0], options.errmsg);
-            return 1;
+            return EXIT_FAILURE;
         }
     }
     argv += options.optind;
@@ -48,29 +49,30 @@ static int cmd_sleep(char **argv)
     struct optparse options;
 
     optparse_init(&options, argv);
-    while ((option = optparse(&options, "h")) != -1) {
+    while ((option = optparse(&options, "?h")) != -1) {
         switch (option) {
-        case 'h':
-            puts("usage: sleep [-h] [NUMBER]...");
-            return 0;
         case '?':
+        case 'h':
+            puts("usage: sleep [-?h] [NUMBER]...");
+            return EXIT_SUCCESS;
+        default:
             fprintf(stderr, "%s: %s\n", argv[0], options.errmsg);
-            return 1;
+            return EXIT_FAILURE;
         }
     }
 
     for (i = 0; argv[i]; i++) {
         if (sleep(atoi(argv[i]))) {
-            return 1;
+            return EXIT_FAILURE;
         }
     }
-    return 0;
+    return EXIT_SUCCESS;
 }
 
 static void
 usage(FILE *f)
 {
-    fprintf(f, "usage: example [-h] <echo|sleep> [OPTION]...\n");
+    fprintf(f, "usage: example [-?h] <echo|sleep> [OPTION]...\n");
 }
 
 int main(int argc, char **argv)
@@ -91,15 +93,16 @@ int main(int argc, char **argv)
     (void)argc;
     optparse_init(&options, argv);
     options.permute = 0;
-    while ((option = optparse(&options, "h")) != -1) {
+    while ((option = optparse(&options, "?h")) != -1) {
         switch (option) {
+        case '?':
         case 'h':
             usage(stdout);
-            return 0;
-        case '?':
+            return EXIT_SUCCESS;
+        default:
             usage(stderr);
             fprintf(stderr, "%s: %s\n", argv[0], options.errmsg);
-            return 1;
+            return EXIT_FAILURE;
         }
     }
 
@@ -107,7 +110,7 @@ int main(int argc, char **argv)
     if (!subargv[0]) {
         fprintf(stderr, "%s: missing subcommand\n", argv[0]);
         usage(stderr);
-        return 1;
+        return EXIT_FAILURE;
     }
 
     for (i = 0; i < ncmds; i++) {
@@ -116,5 +119,5 @@ int main(int argc, char **argv)
         }
     }
     fprintf(stderr, "%s: invalid subcommand: %s\n", argv[0], subargv[0]);
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/optparse.h
+++ b/optparse.h
@@ -46,9 +46,20 @@
  */
 #ifndef OPTPARSE_H
 #define OPTPARSE_H
+#if !(__ASSEMBLER__ + __LINKER__ + 0)
 
 #ifndef OPTPARSE_API
 #  define OPTPARSE_API
+#endif
+
+enum optparse_argtype {
+    OPTPARSE_NONE,
+    OPTPARSE_REQUIRED,
+    OPTPARSE_OPTIONAL
+};
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 struct optparse {
@@ -59,12 +70,6 @@ struct optparse {
     char *optarg;
     char errmsg[64];
     int subopt;
-};
-
-enum optparse_argtype {
-    OPTPARSE_NONE,
-    OPTPARSE_REQUIRED,
-    OPTPARSE_OPTIONAL
 };
 
 struct optparse_long {
@@ -82,7 +87,7 @@ void optparse_init(struct optparse *options, char **argv);
 /**
  * Read the next option in the argv array.
  * @param optstring a getopt()-formatted option string.
- * @return the next option character, -1 for done, or '?' for error
+ * @return the next option character, -1 for done, or 0 for error
  *
  * Just like getopt(), a character followed by no colons means no
  * argument. One colon means the option has a required argument. Two
@@ -114,6 +119,11 @@ int optparse_long(struct optparse *options,
 OPTPARSE_API
 char *optparse_arg(struct optparse *options);
 
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* !(__ASSEMBLER__ + __LINKER__ + 0) */
+
 /* Implementation */
 #ifdef OPTPARSE_IMPLEMENTATION
 
@@ -134,7 +144,7 @@ optparse_error(struct optparse *options, const char *msg, const char *data)
         options->errmsg[p++] = *data++;
     options->errmsg[p++] = '\'';
     options->errmsg[p++] = '\0';
-    return '?';
+    return 0;
 }
 
 OPTPARSE_API

--- a/test.c
+++ b/test.c
@@ -48,7 +48,7 @@ try_optparse_long(char **argv)
         {"color", 'c', OPTPARSE_REQUIRED},
         {"delay", 'd', OPTPARSE_OPTIONAL},
         {"erase", 256, OPTPARSE_REQUIRED},
-        {0, 0, 0}
+        {0, 0, OPTPARSE_NONE}
     };
 
     print_argv(argv);
@@ -73,7 +73,7 @@ static int
 manual_test(int argc, char **argv)
 {
     size_t size = (argc + 1) * sizeof(*argv);
-    char **argv_copy = malloc(size);
+    char **argv_copy = (char **)malloc(size);
 
     memcpy(argv_copy, argv, size);
     printf("\nOPTPARSE\n");
@@ -90,7 +90,7 @@ testsuite(void)
     struct config {
         char amend;
         char brief;
-        char *color;
+        const char *color;
         int delay;
         int erase;
     };
@@ -196,7 +196,7 @@ testsuite(void)
         {"color", 'c', OPTPARSE_OPTIONAL},
         {"delay", 'd', OPTPARSE_REQUIRED},
         {"erase", 'e', OPTPARSE_NONE},
-        {0, 0, 0}
+        {0, 0, OPTPARSE_NONE}
     };
 
     for (i = 0; i < ntests; i++) {


### PR DESCRIPTION
Before:

```c
int option;
struct optparse options = ...
while ((option = optparse(&options, "?")) != -1) {
    switch (option) {
    ...
    case '?':
    default:
        if (option == options.optopt) {
            exit(EXIT_SUCCESS);
        } else {
            exit(EXIT_FAILURE);
        }
    }
}
```

After:

```c
int option;
struct optparse options = ...
while ((option = optparse(&options, "?")) != -1) {
    switch (option) {
    ...
    case '?':
        exit(EXIT_SUCCESS);
    default:
        exit(EXIT_FAILURE);
    }
}
```

While my previous, lengthy description was deleted, I believe this is simple enough.

Disclaimer: I dedicate this contribution to the public domain.