### PR TITLE
make code compatible with `-Wconversion`

### DIFF
--- a/optparse.h
+++ b/optparse.h
@@ -288,7 +288,7 @@ optparse_from_long(const struct optparse_long *longopts, char *optstring)
     for (i = 0; !optparse_longopts_end(longopts, i); i++) {
         if (longopts[i].shortname && longopts[i].shortname < 127) {
             int a;
-            *p++ = longopts[i].shortname;
+            *p++ = (char)longopts[i].shortname;
             for (a = 0; a < (int)longopts[i].argtype; a++)
                 *p++ = ':';
         }

--- a/test.c
+++ b/test.c
@@ -58,7 +58,7 @@ try_optparse_long(char **argv)
         if (opt == '?') {
             printf("%s: %s\n", argv[0], options.errmsg);
         }
-        buf[0] = opt;
+        buf[0] = (char)opt;
         printf("%-6s(%d, %d) = '%s'\n",
                opt < 127 ? buf : longopts[longindex].longname,
                options.optind, longindex, options.optarg);


### PR DESCRIPTION
Title. Bumped into this while using the library. Optparse is a header-only library, so the user can have higher warning levels which can produce warnings in the header. `-Wconversion` is not an unreasonable warning to have enabled, I think it should compile without warnings with it.