### PR TITLE
Implement improved optional optarg parsing for short option.

### DIFF
--- a/examples/long.c
+++ b/examples/long.c
@@ -48,7 +48,12 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Print remaining arguments. */
+    printf("amend : %s\n", amend ? "true" : "false");
+    printf("brief : %s\n", brief ? "true" : "false");
+    printf("color : %s\n", color);
+    printf("delay : %d\n", delay);
+
+    printf("Print remaining arguments:\n");
     while ((arg = optparse_arg(&options)))
         printf("%s\n", arg);
 

--- a/optparse.h
+++ b/optparse.h
@@ -256,6 +256,13 @@ optparse(struct optparse *options, const char *optstring)
         options->optind++;
         if (option[1])
             options->optarg = option + 1;
+#ifdef IMPROVED_OPTPARSE_OPTIONAL
+        else if (next[0] != '-')
+        {
+            options->optarg = next;
+            options->optind++;
+        }
+#endif
         else
             options->optarg = 0;
         return option[0];

--- a/optparse.h
+++ b/optparse.h
@@ -257,7 +257,7 @@ optparse(struct optparse *options, const char *optstring)
         if (option[1])
             options->optarg = option + 1;
 #ifdef IMPROVED_OPTPARSE_OPTIONAL
-        else if (next[0] != '-')
+        else if (next && next[0] != '-')
         {
             options->optarg = next;
             options->optind++;


### PR DESCRIPTION
Given the following simple patch to long.c, the undesirable feature of parsing optional arguments is demonstrated:

    diff --git a/examples/long.c b/examples/long.c
    index 00993fa..4ba63b9 100644
    --- a/examples/long.c
    +++ b/examples/long.c
    @@ -48,7 +48,12 @@ int main(int argc, char **argv)
             }
         }
     
    -    /* Print remaining arguments. */
    +    printf("amend : %s\n", amend ? "true" : "false");
    +    printf("brief : %s\n", brief ? "true" : "false");
    +    printf("color : %s\n", color);
    +    printf("delay : %d\n", delay);
    +
    +    printf("Print remaining arguments:\n");
         while ((arg = optparse_arg(&options)))
             printf("%s\n", arg);
 
First use case fails to reset the delay value.

    %> long.x -d 10 -a bob
    amend : true
    brief : false
    color : white
    delay : 1
    Print remaining arguments:
    10
    bob


Second use case resets the delay value.

    %> long.x -d10 -a bob
    amend : true
    brief : false
    color : white
    delay : 10
    Print remaining arguments:
    bob


Both use cases should behave the same as the second, regardless of the ridculous definition for the GNU extension:

    Two colons mean an option takes an optional arg; if there is text in the current argv-element
    (i.e., in the same word as the option name itself, for example, "-oarg"), then it is returned
    in optarg, otherwise optarg is set to zero."

This preferred behavior is as simple as activating the included patch.
