### PR TITLE
Improved long optarg

### DIFF
--- a/examples/long.c
+++ b/examples/long.c
@@ -48,7 +48,12 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Print remaining arguments. */
+    printf("amend : %s\n", amend ? "true" : "false");
+    printf("brief : %s\n", brief ? "true" : "false");
+    printf("color : %s\n", color);
+    printf("delay : %d\n", delay);
+
+    printf("Print remaining arguments:\n");
     while ((arg = optparse_arg(&options)))
         printf("%s\n", arg);
 

--- a/optparse.h
+++ b/optparse.h
@@ -348,6 +348,7 @@ optparse_long(struct optparse *options,
               int *longindex)
 {
     int i;
+    char *next;
     char *option = options->argv[options->optind];
     if (option == 0) {
         return -1;
@@ -373,6 +374,7 @@ optparse_long(struct optparse *options,
     options->optopt = 0;
     options->optarg = 0;
     option += 2; /* skip "--" */
+    next = options->argv[options->optind + 1];
     options->optind++;
     for (i = 0; !optparse_longopts_end(longopts, i); i++) {
         const char *name = longopts[i].longname;
@@ -392,6 +394,9 @@ optparse_long(struct optparse *options,
                     return optparse_error(options, OPTPARSE_MSG_MISSING, name);
                 else
                     options->optind++;
+            } else if (longopts[i].argtype == OPTPARSE_OPTIONAL) {
+                if (next && next[0] != '-')
+                    options->optarg = options->argv[options->optind++];
             }
             return options->optopt;
         }

--- a/optparse.h
+++ b/optparse.h
@@ -394,9 +394,11 @@ optparse_long(struct optparse *options,
                     return optparse_error(options, OPTPARSE_MSG_MISSING, name);
                 else
                     options->optind++;
+#ifdef IMPROVED_OPTPARSE_OPTIONAL
             } else if (longopts[i].argtype == OPTPARSE_OPTIONAL) {
                 if (next && next[0] != '-')
                     options->optarg = options->argv[options->optind++];
+#endif
             }
             return options->optopt;
         }


### PR DESCRIPTION
Given the following simple patch to long.c, the undesirable feature of parsing optional arguments for  long options is demonstrated:

    diff --git a/examples/long.c b/examples/long.c
    index 00993fa..4ba63b9 100644
    --- a/examples/long.c
    +++ b/examples/long.c
    @@ -48,7 +48,12 @@ int main(int argc, char **argv)
             }
         }
     
    -    /* Print remaining arguments. */
    +    printf("amend : %s\n", amend ? "true" : "false");
    +    printf("brief : %s\n", brief ? "true" : "false");
    +    printf("color : %s\n", color);
    +    printf("delay : %d\n", delay);
    +
    +    printf("Print remaining arguments:\n");
         while ((arg = optparse_arg(&options)))
             printf("%s\n", arg);
 
First use case fails to reset the delay value.

    %> long.x --delay 10 -a bob
    amend : true
    brief : false
    color : white
    delay : 1
    Print remaining arguments:
    10
    bob


Second use case resets the delay value.

    %> long.x --delay=10 -a bob
    amend : true
    brief : false
    color : white
    delay : 10
    Print remaining arguments:
    bob


Both use cases should behave the same as the second.

This preferred behavior is as simple as activating the included patch.
